### PR TITLE
75 upload de imagem base 64

### DIFF
--- a/bin/controllers/companies_images_controller.dart
+++ b/bin/controllers/companies_images_controller.dart
@@ -1,0 +1,94 @@
+import 'dart:convert';
+import 'dart:io';
+import 'package:shelf/shelf.dart';
+import 'package:shelf_router/shelf_router.dart';
+
+import 'controller.dart';
+
+class CompaniesImageController extends Controller {
+  CompaniesImageController();
+
+  @override
+  Handler getHandler({
+    List<Middleware>? middlewares,
+    bool isSecurity = false,
+    bool isJsonMimeType = true,
+  }) {
+    final Router router = Router();
+
+    router.post('/companies-image', (Request request) async {
+      final String body = await request.readAsString();
+      final Map map = jsonDecode(body);
+
+      final String image64FromDB = map['image64'];
+
+      final list = image64FromDB.split(';base64,');
+      final String contentType = list[0].substring(5);
+      final String extension = contentType.split('/')[1];
+
+      final String imageCode = list[1];
+
+      final List<int> bytes = base64.decode(imageCode);
+
+      final directory = Directory('uploads');
+      if (!directory.existsSync()) {
+        directory.createSync();
+      }
+
+      try {
+        final file = File('uploads/${map['companyId']}.$extension');
+        if (!file.existsSync()) {
+          file.writeAsBytesSync(bytes);
+          return Response(201);
+        }
+        return Response.notFound('arquivo já existe!');
+      } catch (e) {
+        print(e.toString());
+        return Response.internalServerError();
+      }
+    });
+
+    router.get('/companies-image/id/<companyID>',
+        (Request request, String? companyID) async {
+      if (companyID == null) {
+        return Response.badRequest();
+      }
+      RegExp uuidRegex = RegExp(
+          '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-1[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}\$');
+      final bool isValid = uuidRegex.hasMatch(companyID);
+
+      if (!isValid) {
+        return Response.badRequest();
+      }
+
+      // Obter a lista de arquivos no diretório atual
+      Directory diretorioAtual = Directory('uploads');
+      List<FileSystemEntity> listaArquivos = diretorioAtual.listSync();
+
+      // Filtrar apenas os arquivos que contêm "meuArquivo" no nome
+      List<File> arquivosFiltrados = listaArquivos
+          .where((arquivo) {
+            return arquivo is File && arquivo.path.contains(companyID);
+          })
+          .map((arquivo) => arquivo as File)
+          .toList();
+
+      // Verificar se há algum arquivo na lista filtrada
+      if (arquivosFiltrados.isNotEmpty) {
+        final fileContents = await arquivosFiltrados.first.readAsBytes();
+        final String extension = arquivosFiltrados.first.path.split('.')[1];
+        return Response.ok(fileContents,
+            headers: {'content-type': 'image/$extension'});
+      } else {
+        return Response(404);
+      }
+    });
+
+    return createHandler(
+      router: router,
+      isSecurity: isSecurity,
+      middlewares: middlewares,
+      isJsonMimeType: isJsonMimeType,
+    );
+  }
+}

--- a/bin/controllers/companies_security_controller.dart
+++ b/bin/controllers/companies_security_controller.dart
@@ -14,7 +14,10 @@ class CompaniesSecurityController extends Controller {
   CompaniesSecurityController(this._companiesService);
 
   @override
-  Handler getHandler({List<Middleware>? middlewares, bool isSecurity = false}) {
+  Handler getHandler(
+      {List<Middleware>? middlewares,
+      bool isSecurity = false,
+      bool isJsonMimeType = true}) {
     Router router = Router();
 
     router.get('/companies', (Request request) async {
@@ -107,7 +110,11 @@ class CompaniesSecurityController extends Controller {
     });
 
     return createHandler(
-        router: router, middlewares: middlewares, isSecurity: isSecurity);
+      router: router,
+      middlewares: middlewares,
+      isSecurity: isSecurity,
+      isJsonMimeType: isJsonMimeType,
+    );
   }
 
   Future<bool> _validateAuth(CompanyModel companyModel, Request request) async {

--- a/bin/controllers/controller.dart
+++ b/bin/controllers/controller.dart
@@ -1,22 +1,33 @@
 import 'package:shelf/shelf.dart';
 
 import '../core/dependency_injector/dependency_injector.dart';
-import '../core/security/security_service.dart';
+import '../core/middlewares/middleware_interception.dart';
 
 abstract class Controller {
-  Handler getHandler({List<Middleware>? middlewares, bool isSecurity = false});
+  Handler getHandler({
+    List<Middleware>? middlewares,
+    bool isSecurity = false,
+    bool isJsonMimeType = true,
+  });
 
-  Handler createHandler(
-      {required Handler router,
-      List<Middleware>? middlewares,
-      bool isSecurity = false}) {
+  Handler createHandler({
+    required Handler router,
+    List<Middleware>? middlewares,
+    bool isSecurity = false,
+    bool isJsonMimeType = true,
+  }) {
     middlewares ??= [];
 
-    if (isSecurity) {
-      SecurityService securityService =
-          DependencyInjector().get<SecurityService>();
-      middlewares
-          .addAll([securityService.authorization, securityService.verifyJwt]);
+    // if (isSecurity) {
+    //   SecurityService securityService =
+    //       DependencyInjector().get<SecurityService>();
+    //   middlewares
+    //       .addAll([securityService.authorization, securityService.verifyJwt]);
+    // }
+    if (isJsonMimeType) {
+      MiddlewareInterception middlewareInterception =
+          DependencyInjector().get<MiddlewareInterception>();
+      middlewares.addAll([middlewareInterception.appJson]);
     }
 
     Pipeline pipe = Pipeline();

--- a/bin/controllers/jobs_controller.dart
+++ b/bin/controllers/jobs_controller.dart
@@ -13,7 +13,10 @@ class JobsController extends Controller {
   JobsController(this._service);
 
   @override
-  Handler getHandler({List<Middleware>? middlewares, bool isSecurity = false}) {
+  Handler getHandler(
+      {List<Middleware>? middlewares,
+      bool isSecurity = false,
+      bool isJsonMimeType = true}) {
     var router = Router();
 
     router.get('/jobs', (Request request) async {
@@ -50,6 +53,7 @@ class JobsController extends Controller {
       router: router,
       isSecurity: isSecurity,
       middlewares: middlewares,
+      isJsonMimeType: isJsonMimeType,
     );
   }
 

--- a/bin/controllers/jobs_report_controller.dart
+++ b/bin/controllers/jobs_report_controller.dart
@@ -13,7 +13,11 @@ class JobsReportController extends Controller {
   JobsReportController(this._jobsReportService);
 
   @override
-  Handler getHandler({List<Middleware>? middlewares, bool isSecurity = false}) {
+  Handler getHandler({
+    List<Middleware>? middlewares,
+    bool isSecurity = false,
+    bool isJsonMimeType = true,
+  }) {
     final Router router = Router();
 
     router.post('/jobs-report', (Request request) async {
@@ -34,6 +38,10 @@ class JobsReportController extends Controller {
     });
 
     return createHandler(
-        router: router, isSecurity: isSecurity, middlewares: middlewares);
+      router: router,
+      isSecurity: isSecurity,
+      middlewares: middlewares,
+      isJsonMimeType: isJsonMimeType,
+    );
   }
 }

--- a/bin/controllers/jobs_security_controller.dart
+++ b/bin/controllers/jobs_security_controller.dart
@@ -14,7 +14,11 @@ class JobsSecurityController extends Controller {
   JobsSecurityController(this._jobsService);
 
   @override
-  Handler getHandler({List<Middleware>? middlewares, bool isSecurity = false}) {
+  Handler getHandler({
+    List<Middleware>? middlewares,
+    bool isSecurity = false,
+    bool isJsonMimeType = true,
+  }) {
     Router router = Router();
 
     router.put('/jobs', (Request request) async {
@@ -90,7 +94,11 @@ class JobsSecurityController extends Controller {
       return result ? Response(201) : Response(404);
     });
     return createHandler(
-        router: router, isSecurity: isSecurity, middlewares: middlewares);
+      router: router,
+      isSecurity: isSecurity,
+      middlewares: middlewares,
+      isJsonMimeType: isJsonMimeType,
+    );
   }
 
   Future<bool> _validateAuth(JobModel job, Request request) async {

--- a/bin/controllers/login_controller.dart
+++ b/bin/controllers/login_controller.dart
@@ -14,7 +14,11 @@ class LoginController extends Controller {
   LoginController(this._authService, this._securityServiceImp);
 
   @override
-  Handler getHandler({List<Middleware>? middlewares, bool isSecurity = false}) {
+  Handler getHandler({
+    List<Middleware>? middlewares,
+    bool isSecurity = false,
+    bool isJsonMimeType = true,
+  }) {
     var router = Router();
 
     router.post('/login', (Request request) async {
@@ -38,6 +42,7 @@ class LoginController extends Controller {
       router: router,
       isSecurity: isSecurity,
       middlewares: middlewares,
+      isJsonMimeType: isJsonMimeType,
     );
   }
 }

--- a/bin/controllers/users_controller.dart
+++ b/bin/controllers/users_controller.dart
@@ -12,7 +12,11 @@ class UsersController extends Controller {
   UsersController(this._usersService);
 
   @override
-  Handler getHandler({List<Middleware>? middlewares, bool isSecurity = false}) {
+  Handler getHandler({
+    List<Middleware>? middlewares,
+    bool isSecurity = false,
+    bool isJsonMimeType = true,
+  }) {
     Router router = Router();
 
     router.post('/users', (Request request) async {
@@ -23,6 +27,10 @@ class UsersController extends Controller {
     });
 
     return createHandler(
-        router: router, isSecurity: isSecurity, middlewares: middlewares);
+      router: router,
+      isSecurity: isSecurity,
+      middlewares: middlewares,
+      isJsonMimeType: isJsonMimeType,
+    );
   }
 }

--- a/bin/controllers/users_security_controller.dart
+++ b/bin/controllers/users_security_controller.dart
@@ -13,7 +13,10 @@ class UsersSecurityController extends Controller {
   UsersSecurityController(this._usersService);
 
   @override
-  Handler getHandler({List<Middleware>? middlewares, bool isSecurity = false}) {
+  Handler getHandler(
+      {List<Middleware>? middlewares,
+      bool isSecurity = false,
+      bool isJsonMimeType = true}) {
     Router router = Router();
 
     router.get('/users', (Request request) async {
@@ -70,7 +73,11 @@ class UsersSecurityController extends Controller {
     });
 
     return createHandler(
-        router: router, isSecurity: isSecurity, middlewares: middlewares);
+      router: router,
+      isSecurity: isSecurity,
+      middlewares: middlewares,
+      isJsonMimeType: isJsonMimeType,
+    );
   }
 
   Future<bool> _validateAuth(Request request) async {

--- a/bin/core/dependency_injector/injects.dart
+++ b/bin/core/dependency_injector/injects.dart
@@ -1,6 +1,7 @@
 import 'package:dotenv/dotenv.dart';
 import 'package:uuid/uuid.dart';
 
+import '../../controllers/companies_images_controller.dart';
 import '../../controllers/companies_security_controller.dart';
 import '../../controllers/jobs_controller.dart';
 import '../../controllers/jobs_report_controller.dart';
@@ -10,6 +11,7 @@ import '../../controllers/ping_controller.dart';
 import '../../dao/companies_dao.dart';
 import '../../controllers/users_controller.dart';
 import '../../controllers/users_security_controller.dart';
+
 import '../../dao/jobs_dao.dart';
 import '../../dao/jobs_report_dao.dart';
 import '../../dao/users_dao.dart';
@@ -17,10 +19,12 @@ import '../../database/db_configuration.dart';
 import '../../database/mysql_db_configuration.dart';
 import '../../services/auth_service.dart';
 import '../../services/companies_service.dart';
+
 import '../../services/jobs_report_service.dart';
 import '../../services/jobs_service.dart';
 import '../../services/permissions_service.dart';
 import '../../services/users_service.dart';
+import '../middlewares/middleware_interception.dart';
 import '../security/security_service.dart';
 import '../security/security_service_imp.dart';
 import 'dependency_injector.dart';
@@ -31,9 +35,10 @@ class Injects {
 
     di.register<DotEnv>(() => DotEnv(includePlatformEnvironment: true)..load());
     di.register<Uuid>(() => Uuid());
+    di.register<MiddlewareInterception>(() => MiddlewareInterception());
 
     di.register<DBConfiguration>(() => MySqlDbConfiguration());
-
+    di.register(() => CompaniesImageController());
     di.register<JobsReportDAO>(() => JobsReportDAO(di.get<DBConfiguration>()));
     di.register<JobsReportService>(
         () => JobsReportService(di.get<JobsReportDAO>()));

--- a/bin/core/security/security_service_imp.dart
+++ b/bin/core/security/security_service_imp.dart
@@ -81,6 +81,9 @@ class SecurityServiceImp implements SecurityService<JWT> {
         if (pathFromUrl.contains('jobs/id/')) {
           pathFromUrl = 'jobs/id';
         }
+        if (pathFromUrl.contains('companies-image/id/')) {
+          pathFromUrl = 'companies-image';
+        }
         var method = request.method.toLowerCase();
         print('method: $method');
         final String validate = '$method-$pathFromUrl';
@@ -89,9 +92,9 @@ class SecurityServiceImp implements SecurityService<JWT> {
         switch (validate) {
           case 'post-login':
           case 'get-jobs':
-          case 'get-companies-image':
           case 'get-jobs/id':
           case 'post-jobs-report':
+          case 'get-companies-image':
             return null;
           default:
             break;

--- a/bin/vagas_flutter_backend.dart
+++ b/bin/vagas_flutter_backend.dart
@@ -1,3 +1,4 @@
+import 'controllers/companies_images_controller.dart';
 import 'controllers/companies_security_controller.dart';
 import 'controllers/jobs_controller.dart';
 import 'controllers/jobs_report_controller.dart';
@@ -7,7 +8,7 @@ import 'controllers/ping_controller.dart';
 import 'controllers/users_controller.dart';
 import 'controllers/users_security_controller.dart';
 import 'core/dependency_injector/injects.dart';
-import 'core/middlewares/middleware_interception.dart';
+
 import 'core/custom_server.dart';
 import 'package:shelf/shelf.dart';
 import 'package:dotenv/dotenv.dart';
@@ -27,13 +28,13 @@ void main() async {
       .add(di.get<JobsSecurityController>().getHandler())
       .add(di.get<CompaniesSecurityController>().getHandler())
       .add(di.get<JobsReportController>().getHandler())
+      .add(di.get<CompaniesImageController>().getHandler(isJsonMimeType: false))
       .handler;
 
   final SecurityService securityService = di.get<SecurityService>();
 
   final pipeline = Pipeline()
       .addMiddleware(logRequests())
-      .addMiddleware(MiddlewareInterception().appJson)
       .addMiddleware(securityService.authorization)
       .addMiddleware(securityService.verifyJwt)
       .addHandler(cascade);


### PR DESCRIPTION
# Atividades

- [x] Criar controlador seguro da rota `/companies-images` para o *endpoint* `CompaniesImageController`
- [x] Adicionar *endpoint* às rotas públicas
   - POST `/companies-image` - exige autenticação
   - GET  `/companies-image/id/<companyID>` - rota pública que retorna um `content-type: image/<extension>` Ex. image/png.
- [x] Refatoração dos controladores que agora possuem optar por não retornar um `content-type: application/json`