### PR TITLE
89 adicionar paginação para vagas

### DIFF
--- a/bin/controllers/jobs_controller.dart
+++ b/bin/controllers/jobs_controller.dart
@@ -99,6 +99,10 @@ class JobsController extends Controller {
                   : "$where (t1.$key like $newValues";
               break;
             }
+            if (key == 'status') {
+              int valueOfStatus = int.tryParse(value) ?? 1;
+              value = valueOfStatus.toString();
+            }
             if (key.contains('name')) {
               where = where == null
                   ? "where t2.$key like '%$value%'"

--- a/bin/controllers/jobs_controller.dart
+++ b/bin/controllers/jobs_controller.dart
@@ -59,9 +59,14 @@ class JobsController extends Controller {
 
   String? _validateQueryParams(Map<String, String> queryParams) {
     String? where;
+    int page = 1;
+    String? pagination;
     queryParams.forEach((key, value) {
       switch (key) {
         case "city":
+        case "page":
+        case "status":
+        case "limit":
         case "modality":
         case "regime":
         case "seniority":
@@ -70,10 +75,13 @@ class JobsController extends Controller {
         case "title":
         case "name":
         case "search":
-          if (queryParams.keys.first != key) where = "$where and ";
+          if (queryParams.keys.first != key &&
+              (key != 'limit' && key != 'page')) {
+            where = "${where ?? ''} and ";
+          }
           if (key == 'search') {
             where =
-                "city like '%$value%' or modality like '%$value%' or regime like '%$value%' or seniority like '%$value%' or title like '%$value%' or t2.name like '%$value%'";
+                "where city like '%$value%' or modality like '%$value%' or regime like '%$value%' or seniority like '%$value%' or title like '%$value%' or t2.name like '%$value%'";
           } else {
             if (value.contains(',')) {
               late String newValues = '';
@@ -82,25 +90,36 @@ class JobsController extends Controller {
                 value = value.trim();
                 if (value.trim() == listOfValue.last.trim()) {
                   newValues += "'%$value%')";
-
                   break;
                 }
                 newValues += "'%$value%' or t1.$key like ";
               }
               where = where == null
-                  ? "(t1.$key like $newValues"
+                  ? "where (t1.$key like $newValues"
                   : "$where (t1.$key like $newValues";
               break;
             }
             if (key.contains('name')) {
               where = where == null
-                  ? "t2.$key like '%$value%'"
-                  : "$where t2.$key like '$value%'";
+                  ? "where t2.$key like '%$value%'"
+                  : "$where t2.$key like '%$value%'";
               break;
             }
+            if (key == 'page') {
+              page = int.tryParse(value) ?? 0;
+              if (page < 0) page *= -1;
+              break;
+            } else if (key == 'limit') {
+              int limit = int.tryParse(value) ?? 10;
+              if (limit < 0) limit *= -1;
+              value = limit.toString();
+              pagination = "limit $value offset ${(page - 1) * 10}";
+              break;
+            }
+
             where = where == null
-                ? "t1.$key like '%$value%'"
-                : "$where t1.$key like '$value%'";
+                ? "where t1.$key like '%$value%'"
+                : "$where t1.$key like '%$value%'";
           }
           break;
 
@@ -109,6 +128,12 @@ class JobsController extends Controller {
           break;
       }
     });
-    return where;
+
+    if (where!.trim().endsWith('and')) {
+      int index = where!.lastIndexOf('and');
+      where = where!.replaceRange(index, null, '');
+    }
+
+    return "$where ${pagination ?? ''}";
   }
 }

--- a/bin/dao/jobs_dao.dart
+++ b/bin/dao/jobs_dao.dart
@@ -98,14 +98,14 @@ class JobDAO implements DAO<JobModel> {
   Future<List<JobModel?>> findByQuery({String? queryParam}) async {
     if (queryParam?.isNotEmpty ?? false) {
       var result = await _dbConfiguration.execQuery(
-          "Select t1.id, t1.title, t1.city,t1.regime, t1.state, t1.created_by, t3.name as status, t1.modality, t2.id as company_id, t2.name as company_name from jobs as t1 inner join companies as t2 on t2.id = t1.company_id inner join jobs_status as t3 on t1.status = t3.id $queryParam ;");
+          "Select t1.id, t1.title, t1.city, t1.regime, t1.state, t1.created_date, t1.created_by, t3.name as status, t1.modality, t2.id as company_id, t2.name as company_name from jobs as t1 inner join companies as t2 on t2.id = t1.company_id inner join jobs_status as t3 on t1.status = t3.id $queryParam ;");
       return result
           .map((r) => JobSimple.fromJson(r.fields))
           .toList()
           .cast<JobSimple>();
     }
     var result = await _dbConfiguration.execQuery(
-        "Select t1.id, t1.title, t1.city, t1.regime, t1.state, t1.created_by, t3.name as status, t1.modality, t2.name as company_name, t2.id as company_id from jobs as t1 inner join companies as t2 on t2.id = t1.company_id inner join jobs_status as t3 on t1.status = t3.id where t1.status='1';");
+        "Select t1.id, t1.title, t1.city, t1.regime, t1.state, t1.created_date, t1.created_by, t3.name as status, t1.modality, t2.name as company_name, t2.id as company_id from jobs as t1 inner join companies as t2 on t2.id = t1.company_id inner join jobs_status as t3 on t1.status = t3.id where t1.status='1';");
     return result
         .map((r) => JobSimple.fromJson(r.fields))
         .toList()

--- a/bin/dao/jobs_dao.dart
+++ b/bin/dao/jobs_dao.dart
@@ -1,5 +1,4 @@
 import 'package:uuid/uuid.dart';
-
 import '../database/db_configuration.dart';
 import '../models/job_details.dart';
 import '../models/job_model.dart';
@@ -99,14 +98,14 @@ class JobDAO implements DAO<JobModel> {
   Future<List<JobModel?>> findByQuery({String? queryParam}) async {
     if (queryParam?.isNotEmpty ?? false) {
       var result = await _dbConfiguration.execQuery(
-          "Select t1.id, t1.title, t1.city,t1.regime, t1.modality, t2.id as company_id, t2.name as company_name from jobs as t1 inner join companies as t2 on t2.id = t1.company_id where $queryParam and t1.status = '1';");
+          "Select t1.id, t1.title, t1.city,t1.regime, t1.state, t1.created_by, t3.name as status, t1.modality, t2.id as company_id, t2.name as company_name from jobs as t1 inner join companies as t2 on t2.id = t1.company_id inner join jobs_status as t3 on t1.status = t3.id $queryParam ;");
       return result
           .map((r) => JobSimple.fromJson(r.fields))
           .toList()
           .cast<JobSimple>();
     }
     var result = await _dbConfiguration.execQuery(
-        "Select t1.id, t1.title, t1.city, t1.regime, t1.modality, t2.name as company_name, t2.id as company_id from jobs as t1 inner join companies as t2 on t2.id = t1.company_id where t1.status = '1';");
+        "Select t1.id, t1.title, t1.city, t1.regime, t1.state, t1.created_by, t3.name as status, t1.modality, t2.name as company_name, t2.id as company_id from jobs as t1 inner join companies as t2 on t2.id = t1.company_id inner join jobs_status as t3 on t1.status = t3.id where t1.status='1';");
     return result
         .map((r) => JobSimple.fromJson(r.fields))
         .toList()

--- a/bin/models/job_simple.dart
+++ b/bin/models/job_simple.dart
@@ -7,24 +7,31 @@ class JobSimple extends JobModel {
   final String companyId;
   final String? regime;
   final String companyName;
+  final String state;
   final String city;
   final String modality;
+  final String jobStatus;
+  final String createdBy;
 
-  JobSimple({
-    required this.companyId,
-    required this.companyName,
-    required this.id,
-    required this.title,
-    required this.regime,
-    required this.city,
-    required this.modality,
-  });
+  JobSimple(
+      {required this.companyId,
+      required this.companyName,
+      required this.id,
+      required this.title,
+      required this.state,
+      required this.regime,
+      required this.city,
+      required this.modality,
+      required this.jobStatus,
+      required this.createdBy});
 
   @override
   Map<String, dynamic> toJson() {
     final result = <String, dynamic>{};
-
+    result.addAll({'status': jobStatus});
+    result.addAll({'created_by': createdBy});
     result.addAll({'id': id});
+    result.addAll({'state': state});
     result.addAll({'title': title});
     result.addAll({'companyName': companyName});
     result.addAll({'companyId': companyId});
@@ -43,12 +50,15 @@ class JobSimple extends JobModel {
       companyName: map['company_name'],
       regime: map['regime'],
       city: map['city'],
+      state: map['state'],
       modality: map['modality'],
+      jobStatus: map['status'],
+      createdBy: map['created_by'],
     );
   }
 
   @override
   String toString() {
-    return 'JobSimple(id: $id, title: $title,companyName: $companyName,regime: $regime, city: $city, modality: $modality)';
+    return 'JobSimple(id: $id, title: $title, companyName: $companyName, status: $status, createdBy: $createdBy, regime: $regime, city: $city, state: $state, modality: $modality)';
   }
 }

--- a/bin/models/job_simple.dart
+++ b/bin/models/job_simple.dart
@@ -11,6 +11,7 @@ class JobSimple extends JobModel {
   final String city;
   final String modality;
   final String jobStatus;
+  final DateTime? createdDate;
   final String createdBy;
 
   JobSimple(
@@ -23,6 +24,7 @@ class JobSimple extends JobModel {
       required this.city,
       required this.modality,
       required this.jobStatus,
+      this.createdDate,
       required this.createdBy});
 
   @override
@@ -38,6 +40,10 @@ class JobSimple extends JobModel {
     result.addAll({'regime': regime});
     result.addAll({'city': city});
     result.addAll({'modality': modality});
+    result.addAll({
+      if (createdDate != null)
+        'createdDate': createdDate?.millisecondsSinceEpoch,
+    });
 
     return result;
   }
@@ -54,11 +60,12 @@ class JobSimple extends JobModel {
       modality: map['modality'],
       jobStatus: map['status'],
       createdBy: map['created_by'],
+      createdDate: map['created_date'],
     );
   }
 
   @override
   String toString() {
-    return 'JobSimple(id: $id, title: $title, companyName: $companyName, status: $status, createdBy: $createdBy, regime: $regime, city: $city, state: $state, modality: $modality)';
+    return 'JobSimple(id: $id, title: $title, companyName: $companyName, status: $status,createdDate: $createdDate, createdBy: $createdBy, regime: $regime, city: $city, state: $state, modality: $modality)';
   }
 }

--- a/specs/swagger.yaml
+++ b/specs/swagger.yaml
@@ -60,6 +60,16 @@ paths:
             type: string
             description: General search.
         - in: query
+          name: page
+          schema:
+            type: string
+            description: Choose the pagination of the search.Ex page=1 return itens starts from the 1° position, page=2 returns itens starts from the 11° position. If not pass this arguments set to 1.
+        - in: query
+          name: limit
+          schema:
+            type: string
+            description: Set the maximum quantity of itens from a page.
+        - in: query
           name: name
           schema:
             type: string
@@ -665,6 +675,18 @@ components:
           format: uuid
         title:
           type: string
+        state:
+          type: string
+        status:
+          type: string
+          enum:
+          - "paused"
+          - "active"
+          - "canceled"
+          - "completed"
+        createdBy:
+          type: string
+          format: uuid
         regime:
           type: string
         companyName:

--- a/specs/swagger.yaml
+++ b/specs/swagger.yaml
@@ -50,16 +50,6 @@ paths:
       - "jobs"
       parameters:
         - in: query
-          name: city
-          schema:
-            type: string
-            description: The city of a job that contains the value. Ex. São Paulo.
-        - in: query
-          name: search
-          schema:
-            type: string
-            description: General search.
-        - in: query
           name: page
           schema:
             type: string
@@ -69,6 +59,27 @@ paths:
           schema:
             type: string
             description: Set the maximum quantity of itens from a page.
+        - in: query
+          name: status
+          schema:
+            type: integer
+            enum: [0, 1, 2, 3]
+          description: |
+              The status of the resource.
+              - 0: "canceled"
+              - 1: "active"
+              - 2: "paused"
+              - 3: "completed"
+        - in: query
+          name: city
+          schema:
+            type: string
+            description: The city of a job that contains the value. Ex. São Paulo.
+        - in: query
+          name: search
+          schema:
+            type: string
+            description: General search.
         - in: query
           name: name
           schema:
@@ -687,6 +698,8 @@ components:
         createdBy:
           type: string
           format: uuid
+        createdDate:
+          type: integer
         regime:
           type: string
         companyName:


### PR DESCRIPTION
- Adicionados os campos : status, created_by, created_date e state na busca de jobs.

- Liberação da paginação dos filtros que funcionará da seguinte forma:
passamos dois campos:
    - o campo page
page=1 retorna a partir do 1° registro. page=2 retorna a partir do 11 registro . page=3 retorna a partir do 21 registro....
    - o campo limit
determina a quantidade de registros por página. Ex limit 3 - retorna 3 registros da página especificada.

- Atualizada documentação
